### PR TITLE
Add custom feature bounds support for tabular data compatibility

### DIFF
--- a/src/attacks/BlackBoxAttacks.jl
+++ b/src/attacks/BlackBoxAttacks.jl
@@ -1,17 +1,22 @@
 """
-    BasicRandomSearch(parameters::Dict=Dict{String,Any}())
+    BasicRandomSearch(; epsilon=0.1, bounds=nothing)
 
-Subtype of BlackBoxAttack. Can be used to create an adversarial example in the black-box setting using random search.
+Subtype of BlackBoxAttack. Creates adversarial examples using the SimBA random search algorithm.
 
 # Arguments
-- 'parameters': can be used to pass attack parameters as a dict
+- `epsilon`: Step size for perturbations (default: 0.1)
+- `bounds`: Optional vector of (lower, upper) tuples specifying per-feature bounds.
+            If `nothing`, defaults to [0, 1] for all features (suitable for normalized images).
+            For tabular data, provide bounds matching feature ranges, e.g.,
+            `[(4.3, 7.9), (2.0, 4.4), ...]` for Iris-like data.
 """
-struct BasicRandomSearch <: BlackBoxAttack
-    parameters::Dict{String,Any}
+struct BasicRandomSearch{T<:Real, B<:Union{Nothing, Vector{<:Tuple{Real,Real}}}} <: BlackBoxAttack
+    epsilon::T
+    bounds::B
+end
 
-    function BasicRandomSearch(parameters::Dict=Dict{String,Any}())
-        new(Dict{String,Any}(parameters))
-    end
+function BasicRandomSearch(; epsilon::Real=0.1, bounds=nothing)
+    BasicRandomSearch(epsilon, bounds)
 end
 
 
@@ -48,25 +53,28 @@ Performs a black-box adversarial attack on the given model using the provided sa
 function craft(sample, model::AbstractModel, attack::BasicRandomSearch)
     x = sample.data
     y = sample.label
+    n = length(x)
 
-    ε = convert(eltype(x), get(attack.parameters, "epsilon", attack.parameters["epsilon"]))
-    bounds = get(attack.parameters, "bounds", nothing)
+    ε = convert(eltype(x), attack.epsilon)
 
-    ndims = length(x)
-    perm = randperm(ndims)
-
-    if bounds === nothing
-        lb, ub = zeros(eltype(x), ndims), ones(eltype(x), ndims)
+    # Set up bounds
+    if attack.bounds === nothing
+        lb = zeros(eltype(x), n)
+        ub = ones(eltype(x), n)
     else
-        lb = [b[1] for b in bounds]
-        ub = [b[2] for b in bounds]
+        if length(attack.bounds) != n
+            throw(DimensionMismatch("bounds length ($(length(attack.bounds))) must match input dimensions ($n)"))
+        end
+        lb = eltype(x)[b[1] for b in attack.bounds]
+        ub = eltype(x)[b[2] for b in attack.bounds]
     end
 
+    perm = randperm(n)
     pred = model.model(x)
     last_prob = pred[y]
-    #println("Initial probability of true class: ", pred)
-    for i in 1:ndims
-        diff = zeros(eltype(x), ndims)
+
+    for i in 1:n
+        diff = zeros(eltype(x), n)
         diff[perm[i]] = ε
         δ = reshape(diff, size(x))
 
@@ -78,7 +86,6 @@ function craft(sample, model::AbstractModel, attack::BasicRandomSearch)
         else
             x_right = clamp.(x .+ δ, lb, ub)
             right_prob = model.model(x_right)[y]
-            #print("Iteration $i: Left prob = $left_prob, Right prob = ")
             if right_prob < last_prob
                 last_prob = right_prob
                 x = x_right

--- a/test/attacks/BlackBoxAttacks.jl
+++ b/test/attacks/BlackBoxAttacks.jl
@@ -13,13 +13,20 @@ AdversarialAttacks.predict(::DummyBlackBoxModel, x) = x
     # Test default constructor
     attack = BasicRandomSearch()
     @test attack isa BasicRandomSearch
-    @test attack.parameters == Dict{String,Any}()
+    @test attack.epsilon == 0.1
+    @test attack.bounds === nothing
 
     # Test constructor with parameters
-    params = Dict{String,Any}("epsilon" => 0.25)
-    attack_with_params = BasicRandomSearch(params)
+    attack_with_params = BasicRandomSearch(epsilon=0.25)
     @test attack_with_params isa BasicRandomSearch
-    @test attack_with_params.parameters == params
+    @test attack_with_params.epsilon == 0.25
+    @test attack_with_params.bounds === nothing
+
+    # Test constructor with bounds
+    bounds = [(0.0, 1.0), (0.0, 2.0)]
+    attack_with_bounds = BasicRandomSearch(epsilon=0.1, bounds=bounds)
+    @test attack_with_bounds.epsilon == 0.1
+    @test attack_with_bounds.bounds == bounds
 
     # Test type hierarchy
     @test BasicRandomSearch <: BlackBoxAttack
@@ -36,10 +43,7 @@ AdversarialAttacks.predict(::DummyBlackBoxModel, x) = x
     @test size(result) == size(sample.data)
     @test eltype(result) == eltype(sample.data)
     @test x_copy == sample.data
-    @test result != sample.data #as we know epsilon is larger 0 here
-    # TODO: Add tests for different models
-
-
+    @test result != sample.data  # epsilon > 0, so perturbation expected
 end
 
 @testset "BasicRandomSearch SimBA core behavior" begin
@@ -55,7 +59,7 @@ end
     end
 
     ε = 0.1f0
-    atk = BasicRandomSearch(Dict("epsilon" => ε))
+    atk = BasicRandomSearch(epsilon=ε)
 
     # Case 1: left move should be chosen at least once
     sample_left = (data=Float32[0.5, 0.5, 0.5, 0.5], label=1)
@@ -107,14 +111,14 @@ end
     # Iris-like bounds: per-feature [lb, ub]
     iris_bounds = [(4.3f0, 7.9f0), (2.0f0, 4.4f0), (1.0f0, 6.9f0), (0.1f0, 2.5f0)]
 
-    # Test 1: Bounds parsing from parameters
-    attack_bounds = BasicRandomSearch(Dict("epsilon" => 0.1f0, "bounds" => iris_bounds))
-    @test haskey(attack_bounds.parameters, "bounds")
-    @test attack_bounds.parameters["bounds"] == iris_bounds
+    # Test 1: Bounds stored correctly in struct
+    attack_bounds = BasicRandomSearch(epsilon=0.1f0, bounds=iris_bounds)
+    @test attack_bounds.bounds == iris_bounds
+    @test attack_bounds.epsilon == 0.1f0
 
-    # Test 2: Default [0,1] bounds when nothing provided
-    attack_default = BasicRandomSearch(Dict("epsilon" => 0.1f0))
-    @test !haskey(attack_default.parameters, "bounds")
+    # Test 2: Default bounds is nothing
+    attack_default = BasicRandomSearch(epsilon=0.1f0)
+    @test attack_default.bounds === nothing
 
     # Test 3: SumModel with custom bounds - left direction clamped correctly
     struct BoundedSumModel <: AbstractModel end
@@ -126,26 +130,26 @@ end
 
     # Sample near lower bound, expect clamping
     sample_near_lb = (data=Float32[4.4, 2.1, 1.1, 0.2], label=1)  # just above iris_bounds lb
-    attack_near_lb = BasicRandomSearch(Dict("epsilon" => 0.2f0, "bounds" => iris_bounds))
+    attack_near_lb = BasicRandomSearch(epsilon=0.2f0, bounds=iris_bounds)
     adv_near_lb = craft(sample_near_lb, BoundedSumModel(), attack_near_lb)
 
     @test all(adv_near_lb .>= [4.3, 2.0, 1.0, 0.1])     # >= lb
-    @test all(adv_near_lb .<= [7.9, 4.4, 6.9, 2.5])     # <= ub  
-    @test any(adv_near_lb .< sample_near_lb.data)     # decreased (success)
+    @test all(adv_near_lb .<= [7.9, 4.4, 6.9, 2.5])     # <= ub
+    @test any(adv_near_lb .< sample_near_lb.data)       # decreased (success)
 
     # Test 4: No bounds → [0,1] default (image compatibility)
-    attack_no_bounds = BasicRandomSearch(Dict("epsilon" => 0.1f0))
+    attack_no_bounds = BasicRandomSearch(epsilon=0.1f0)
     sample_image = (data=Float32[0.2, 0.8, 0.3, 0.9], label=1)
     adv_image = craft(sample_image, BoundedSumModel(), attack_no_bounds)
-    @test all(0 .<= adv_image .<= 1)                  # [0,1] respected
-    @test any(adv_image .< sample_image.data)         # perturbation applied
+    @test all(0 .<= adv_image .<= 1)                    # [0,1] respected
+    @test any(adv_image .< sample_image.data)           # perturbation applied
 
     # Test 5: Bounds length validation (should error on mismatch)
     invalid_bounds = [(0.0f0, 1.0f0), (0.0f0, 1.0f0), (0.0f0, 1.0f0)]  # 3 bounds for 4 features
     @test_throws DimensionMismatch craft(
         sample_near_lb,
         BoundedSumModel(),
-        BasicRandomSearch(Dict("epsilon" => 0.1f0, "bounds" => invalid_bounds)),
+        BasicRandomSearch(epsilon=0.1f0, bounds=invalid_bounds),
     )
 end
 


### PR DESCRIPTION
Currently the SimBA attack implementation assumes [0,1] bounds for all features, which works for normalized image pixels but fails for tabular datasets like Iris where features have natural ranges (e.g., sepal length [4.3,7.9], petal width [0.1,2.5]).