### PR TITLE
use vec() to handle 2D model outputs in argmax

### DIFF
--- a/src/Evaluation.jl
+++ b/src/Evaluation.jl
@@ -153,14 +153,14 @@ function evaluate_robustness(
         try
             # clean output
             clean_pred = model(sample.data)
-            clean_label = argmax(clean_pred)
+            clean_label = argmax(vec(clean_pred))
             is_clean_correct = (clean_label == true_label)
             num_clean_correct += is_clean_correct
 
             # adverserial output
             adv_data = attack(atk, model, sample)
             adv_pred = model(adv_data)
-            adv_label = argmax(adv_pred)
+            adv_label = argmax(vec(adv_pred))
             is_adv_correct = (adv_label == true_label)
             num_adv_correct += is_adv_correct
 


### PR DESCRIPTION
## Problem

The `evaluate_robustness()` function in `src/Evaluation.jl` fails to correctly identify clean predictions when the model outputs a 2D array (e.g., `(n_classes, 1)` for single samples) instead of a 1D vector.

### Root Cause

Julia's `argmax()` behaves differently depending on input dimensionality:

```julia
# 1D vector
pred_1d = [0.1, 0.8, 0.3]  # Shape: (3,)
argmax(pred_1d)  # → 2 (Int64) ✓

# 2D matrix (single sample batch)
pred_2d = [0.1; 0.8; 0.3;;]  # Shape: (3, 1)
argmax(pred_2d)  # → CartesianIndex(2, 1) ✗
```

This causes comparison failures:
```julia
true_label = 2  # Int64
clean_label = argmax(pred_2d)  # CartesianIndex(2, 1)
clean_label == true_label  # false! ✗
```

### Impact

- All samples were incorrectly marked as "clean-incorrect" (`num_clean_correct = 0`)
- Attack Success Rate (ASR) always reported as 0.0%
- Made robustness evaluation completely broken for Flux models that output 2D arrays

## Solution

Use `vec()` to flatten model predictions before `argmax()`:

```julia
# Before
clean_label = argmax(clean_pred)  # Fails with 2D output

# After
clean_label = argmax(vec(clean_pred))  # Works with both 1D and 2D
```

`vec()` is idempotent for 1D arrays and flattens 2D arrays, making it safe for all cases:
- 1D input `(n,)` → 1D output `(n,)`
- 2D input `(n, 1)` → 1D output `(n,)`
