### PR TITLE
Consolidate epsilon parameter name in api

### DIFF
--- a/src/Evaluation.jl
+++ b/src/Evaluation.jl
@@ -245,7 +245,7 @@ and perturbation statistics for L∞, L2, and L1 norms.
 
 # Example
 ```julia
-report = evaluate_robustness(model, FGSM(ε=0.1), test_data, num_samples=50)
+report = evaluate_robustness(model, FGSM(epsilon=0.1), test_data, num_samples=50)
 println(report)
 ```
 """


### PR DESCRIPTION
- chore(api): change frontend to use parameter name `epsilon` instead of ϵ in Evaluation.jl