### PR TITLE
CompatHelper: bump compat for MLJ to 0.23, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AdversarialAttacks"
 uuid = "0930d2b9-30a9-4ff9-b124-6eb7688acdd1"
-authors = ["Mathilda Buschmann <@m-buschmann>", "Ezra Cerpac <@EzraCerpac>", "Lea Emilia Friedemann <@escatay>", "Hailey Gu <@hhggu>", "Orestis Papandreou <@shnaky>"]
 version = "1.0.1"
+authors = ["Mathilda Buschmann <@m-buschmann>", "Ezra Cerpac <@EzraCerpac>", "Lea Emilia Friedemann <@escatay>", "Hailey Gu <@hhggu>", "Orestis Papandreou <@shnaky>"]
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -22,7 +22,7 @@ Distributions = "0.25.123"
 Downloads = "1.6.0"
 Flux = "0.16.7"
 LinearAlgebra = "1.11.0"
-MLJ = "0.22.0"
+MLJ = "0.22.0, 0.23"
 Pkg = "1.11.0"
 Random = "1.11.0"
 Statistics = "1.11.1"


### PR DESCRIPTION
This pull request changes the compat entry for the `MLJ` package from `0.22.0` to `0.22.0, 0.23`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.